### PR TITLE
Adjustments for PIXI v3

### DIFF
--- a/pixi.dom.js
+++ b/pixi.dom.js
@@ -101,7 +101,7 @@
 	var generateFakeTexture = function(w, h) {
 		return {
 			baseTexture: { hasLoaded: true },
-			frame: { width: w, height: h }
+			_frame: { width: w, height: h }
 		};
 	};
 
@@ -162,7 +162,7 @@
 
 	/* pixi.js doesn't render / touch children of hidden sprites at all, so we have to go all the way up to find out if we are invisible or not */
 	var invisbilityCheck = function(displayObject) {
-		return !displayObject.visible || displayObject.alpha <= 0 || (displayObject.stage !== displayObject && (!displayObject.parent || invisbilityCheck(displayObject.parent)));
+		return !displayObject.visible || displayObject.alpha <= 0 || (displayObject.parent !== null && invisbilityCheck(displayObject.parent));
 	};
 
 	//


### PR DESCRIPTION
some adjustments to work with the current PIXI 3: use "_frame" instead of "frame" in the fake-texture and remove the check for stage (because PIXI v3 does not have a stage anymore)
